### PR TITLE
Add `createBaseDir()` function to Home component

### DIFF
--- a/components/Home.js
+++ b/components/Home.js
@@ -1,7 +1,16 @@
 import React from 'react';
 
+import remote from 'remote';
+
+const FileUtils = remote.require('./utils/FileUtils');
+
 export default class Home extends React.Component {
   displayName: 'Home';
+
+  constructor() {
+    super();
+    FileUtils.createBaseDir();
+  }
 
   render() {
     return (

--- a/utils/FileUtils.js
+++ b/utils/FileUtils.js
@@ -1,8 +1,21 @@
-import fs from 'fs-extra';
-import path from 'path';
+const fs   = require('fs-extra');
+const path = require('path');
 
-export default class FileUtils {
-  static createSlideDir(slidePath = '') {
+const FileUtils = {
+  createBaseDir: function() {
+    fs.mkdirp(path.join(FileUtils.baseDir()), (err) => {
+      if (err) {
+        console.error(err);
+        return false;
+      }
+    });
+
+    return true;
+  },
+
+  createSlideDir: function(_slidePath) {
+    const slidePath = (_slidePath) ? _slidePath : '';
+
     fs.mkdirp(path.join(FileUtils.baseDir(), slidePath), (err) => {
       if (err) {
         console.error(err);
@@ -11,13 +24,15 @@ export default class FileUtils {
     });
 
     return true;
-  }
+  },
 
-  static homeDir() {
+  homeDir: function() {
     return process.env.HOME || process.env.USERPROFILE;
-  }
+  },
 
-  static baseDir() {
+  baseDir: function() {
     return path.join(FileUtils.homeDir(), '.zatpr');
   }
-}
+};
+
+module.exports = FileUtils;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,8 @@ var ROOT_PATH = path.resolve(__dirname);
 var TARGET    = process.env.npm_lifecycle_event;
 
 var common = {
+  target: 'atom',
+
   entry: path.resolve(ROOT_PATH, 'main.jsx'),
 
   output: {
@@ -15,7 +17,11 @@ var common = {
 
   resolve: {
     extensions: ['', '.js', '.jsx']
-  }
+  },
+
+  externals: [
+    'FileUtils'
+  ]
 };
 
 if (TARGET === 'build') {


### PR DESCRIPTION
I add creating `$HOME/.zatpr` to Home component.

I modify `webpack.config.js` to be able to use electron's library `remote`, add `externals` and `target: 'atom'`.

TODO
- [ ] ~~Adding webpack.config.test.js(now cannot use espower one liner...)~~

※ To be able to run tests, I attempt to set up webpack.config.js for test and karma(maybe), so that I create another PR including be able to run tests... 
